### PR TITLE
One more big cleanup pass hopefully

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@ This main window reveals a lot of information.
 
 * The window title bar shows the program version
 
-* The menu dropdown allows the user to specify a language, toggle whether to keep intermediate files, whether to copy final outputs to the original IDF dir, view the About dialog, or exit the program.
+* The menu dropdown allows the user to specify a language, toggle whether to keep intermediate files, view the About dialog, or exit the program.
 
 * The first section of the main form is about specifying an EnergyPlus install directory; upon selecting a folder, the label will include extra information
 
@@ -47,7 +47,7 @@ Instead of manually updating each input file, they will:
 
 * Click the ``Update`` button to initiate the transition up to the latest version.  For this example, it would transition from 8.1 to 23.1 without any extra steps.  If the original input file was an older version, multiple transition steps would be performed to get to the latest version
 
-* The user would then click the ``Open Run Directory`` button to open a window to the new input file, and copy it to be placed back into the user's desired location to be run with the latest version (23.1 in this example)
+* The user would then click the ``Open Directory`` button to open a window to the input file location to be run with the latest version (23.1 in this example)
 
 -------------------------
 Source Code Documentation

--- a/energyplus_transition/international.py
+++ b/energyplus_transition/international.py
@@ -43,9 +43,8 @@ EnglishDictionary: dict[str, str] = {
     'List File Version': 'List file may contain multiple versions of files',
     'Menu': 'Menu',
     'Old Version': 'Original IDF Version',
-    'Open Input Directory': 'Open Input Directory',
+    'Open Directory': 'Open Directory',
     'Open File for Transition': 'Open File for Transition',
-    'Open Run Directory': 'Open Run Directory',
     'OUTPUT_PATH':
         'Choose where to place output files, either in the run directory '
         'with the transition binaries, or in the original IDF directory',
@@ -94,8 +93,7 @@ SpanishDictionary: dict[str, str] = {
     'Menu': 'Menú',
     'Old Version': 'Version antigua',
     'Open File for Transition': 'Abrir archivo para la Transición',
-    'Open Input Directory': 'NEED TRANSLATION',
-    'Open Run Directory': 'Directorio de ejecución abierta',
+    'Open Directory': 'NEED TRANSLATION',
     'OUTPUT_PATH': 'NEED TRANSLATION',
     'Program Initialized': 'Programa Initialized',
     'Running Transition': 'Transición corriendo',
@@ -141,8 +139,7 @@ FrenchDictionary: dict[str, str] = {
     'Menu': 'Menu',
     'Old Version': 'Ancienne version',
     'Open File for Transition': 'Ouvrir un fichier pour la transition',
-    'Open Input Directory': 'NEED TRANSLATION',
-    'Open Run Directory': 'Ouvrir le répertoire d\'éxécution',
+    'Open Directory': 'NEED TRANSLATION',
     'OUTPUT_PATH': 'NEED TRANSLATION',
     'Cannot find a matching transition tool for this idf version':
         'Impossible de trouver un utilitaire de Transition pour cette version d\'IDF',

--- a/energyplus_transition/tests/test_transition_run_thread.py
+++ b/energyplus_transition/tests/test_transition_run_thread.py
@@ -15,7 +15,6 @@ class Test(TestCase):
         copy(temp_file, temp_run_dir)
         t = TransitionRunThread(
             transitions_to_run={},
-            copy_to_idf_dir=False,
             working_directory=temp_run_dir,
             keep_old=False,
             increment_callback=lambda x: x,


### PR DESCRIPTION
- Removed the option about copying files to input directory.  We're just running transition in that directory so those automatically live there. Thanks @jmarrec 
- Track the transition audit file and provide an accumulated version
- Now it also tracks the VCPerr file also